### PR TITLE
Fixed AMF3 encoding an object with a header byte larger than 127

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -363,7 +363,7 @@
     }
     header = keyCount << 4 | (externalizable ? 1 : 0) << 2;
     header = (header | 2) | 1;
-    this.write(header);
+    AMF3.INTEGER.encode.call(this, header);
     this.serialize(value["__class"], AMF3);
     if (externalizable) {
       return value.write(this);

--- a/src/encoder.coffee
+++ b/src/encoder.coffee
@@ -243,7 +243,7 @@ AMF3.OBJECT.encode = (value) ->
 	header = keyCount << 4 | (if externalizable then 1 else 0) << 2
 	header = ((header | 2) | 1)
 
-	@write header
+	AMF3.INTEGER.encode.call this, header
 	@serialize value["__class"], AMF3
 	return value.write @ if externalizable
 	Object.keys(value).forEach (key) =>

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -248,3 +248,31 @@ describe "amf.js - AMF3", ->
 		read.should.have.deep.property('d.length').equal 3
 		read.should.have.deep.property('e.__class').equal "my.nested.empty.object"
 		read.should.have.deep.property('f.__class').equal undefined
+
+	it "should be able to serialize types with large interface", ->
+		theObject = new amf_js.Serializable "my.test.object"
+		theObject.a = 10
+		theObject.b = 20.333333
+		theObject.c = "SomeValue"
+		theObject.d = [1, 2, 3]
+		theObject.e = 10
+		theObject.f = 10
+		theObject.g = 10
+		theObject.h = 10
+		theObject.i = 10
+		theObject.j = 10
+		theObject.k = 10
+		theObject.l = 10
+		theObject.m = 10
+		theObject.n = 10
+		theObject.o = 10
+		theObject.p = 10
+
+		encoder.writeObject theObject, AMF3
+		read = decoder.decode(AMF3)
+
+		read.should.be.an.instanceof amf_js.Serializable
+		read.should.have.property('a').equal 10
+		read.should.have.property('b').equal 20.333333
+		read.should.have.property('c').equal "SomeValue"
+		read.should.have.property('p').equal 10


### PR DESCRIPTION
Hi @molenzwiebel I came across this issue when trying to encode an object with a large number of properties. 
Rather than calling write with the header value I am passing it to the AM3.INTEGER.encode method. Not sure if this is the best approach but it fixed the issue in our projects. 
Tests included.

Thanks
Justin
